### PR TITLE
Survivor 2 enemies

### DIFF
--- a/RDXplorer/Enumeration/EnemyEnumeration.cs
+++ b/RDXplorer/Enumeration/EnemyEnumeration.cs
@@ -97,8 +97,8 @@
         NemesisCutscene = 103,
         Nemesis = 104,
         DestructibleObject = 105, // doesn't include crates, which are a variant of explosive barrel
-        Unknown107 = 107,
+        EnemySpawnerWoodenBox = 107,
         EnemySpawnerPipe = 108,
-        EnemySpawnerBox = 109,
+        EnemySpawnerMetalBox = 109,
     }
 }

--- a/RDXplorer/Enumeration/EnemyEnumeration.cs
+++ b/RDXplorer/Enumeration/EnemyEnumeration.cs
@@ -42,7 +42,7 @@
 
         FatherBurnside = 51,
         AlexanderAshford = 52,
-        Unknown53 = 53,
+        NosferatuCore = 53,
         Unknown54 = 54,
         Unknown55 = 55,
         Unknown56 = 56,
@@ -89,5 +89,16 @@
         Wesker = 97,
         Rodrigo = 98,
         Scientist = 99,
+
+        // Survivor 2
+        Coin = 100,
+        DrainDeimos = 101,
+        Licker = 102,
+        NemesisCutscene = 103,
+        Nemesis = 104,
+        DestructibleObject = 105, // doesn't include crates, which are a variant of explosive barrel
+        Unknown107 = 107,
+        EnemySpawnerPipe = 108,
+        EnemySpawnerBox = 109,
     }
 }

--- a/RDXplorer/Lookups.cs
+++ b/RDXplorer/Lookups.cs
@@ -219,7 +219,7 @@ namespace RDXplorer
 
                     _actors.Add(EnemyEnumeration.FatherBurnside, "Father Burnside");
                     _actors.Add(EnemyEnumeration.AlexanderAshford, "Alexander Ashford (Nosferatu)");
-                    _actors.Add(EnemyEnumeration.Unknown53, "Unknown");
+                    _actors.Add(EnemyEnumeration.NosferatuCore, "Nosferatu Core");
                     _actors.Add(EnemyEnumeration.Unknown54, "Unknown");
                     _actors.Add(EnemyEnumeration.Unknown55, "Unknown");
                     _actors.Add(EnemyEnumeration.Unknown56, "Unknown");
@@ -266,6 +266,17 @@ namespace RDXplorer
                     _actors.Add(EnemyEnumeration.Wesker, "Albert Wesker");
                     _actors.Add(EnemyEnumeration.Rodrigo, "Rodrigo Raval");
                     _actors.Add(EnemyEnumeration.Scientist, "Scientist");
+
+                    // Survivor 2
+                    _actors.Add(EnemyEnumeration.Coin, "Coin");
+                    _actors.Add(EnemyEnumeration.DrainDeimos, "Drain Deimos");
+                    _actors.Add(EnemyEnumeration.Licker, "Licker");
+                    _actors.Add(EnemyEnumeration.NemesisCutscene, "Nemesis (Cutscene)");
+                    _actors.Add(EnemyEnumeration.Nemesis, "Nemesis");
+                    _actors.Add(EnemyEnumeration.DestructibleObject, "Destructible Object");
+                    _actors.Add(EnemyEnumeration.Unknown107, "Unknown");
+                    _actors.Add(EnemyEnumeration.EnemySpawnerPipe, "Enemy Spawner (Pipe)");
+                    _actors.Add(EnemyEnumeration.EnemySpawnerBox, "Enemy Spawner (Box)");
                 }
 
                 return _actors;

--- a/RDXplorer/Lookups.cs
+++ b/RDXplorer/Lookups.cs
@@ -274,9 +274,9 @@ namespace RDXplorer
                     _actors.Add(EnemyEnumeration.NemesisCutscene, "Nemesis (Cutscene)");
                     _actors.Add(EnemyEnumeration.Nemesis, "Nemesis");
                     _actors.Add(EnemyEnumeration.DestructibleObject, "Destructible Object");
-                    _actors.Add(EnemyEnumeration.Unknown107, "Unknown");
+                    _actors.Add(EnemyEnumeration.EnemySpawnerWoodenBox, "Enemy Spawner (Wooden Box)");
                     _actors.Add(EnemyEnumeration.EnemySpawnerPipe, "Enemy Spawner (Pipe)");
-                    _actors.Add(EnemyEnumeration.EnemySpawnerBox, "Enemy Spawner (Box)");
+                    _actors.Add(EnemyEnumeration.EnemySpawnerMetalBox, "Enemy Spawner (Metal Box)");
                 }
 
                 return _actors;


### PR DESCRIPTION
As I mentioned in #3 , I've been digging into Survivor 2, and I wanted to add support for its additional enemies to this tool. I don't believe there's any overlap in the enemy IDs, so it shouldn't have any impact on exploring the original CV files.

I also identified enemy 53 as Nosferatu's core. While I haven't looked much into the specific behavior of this "enemy", it appears always and only in rooms with Nosferatu, and it's identified in the code as `Core`, so it seems like a pretty safe ID to me.